### PR TITLE
Version 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-phpdoc",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "PHPDoc grammar for tree-sitter",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
@claytonrcarter I was playing around with #20 and found that the version you get with `npm install tree-sitter-phpdoc` is outdated. I think this should bump the version with npmjs.com.
