### PR TITLE
fix: remove getenv, conditionally include stdio, make package_version const

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1,8 +1,13 @@
 #include <tree_sitter/parser.h>
-#include <wctype.h>
-#include <stdio.h>
 
-#define LOG(...) if (getenv("TREE_SITTER_DEBUG")) { printf(__VA_ARGS__); }
+#define TSDEBUG 0
+
+#if TSDEBUG
+#include <stdio.h>
+#define LOG(...)  fprintf(stderr, __VA_ARGS__)
+#else
+#define LOG(...)
+#endif
 
 enum TokenType {
   TEXT,
@@ -12,7 +17,7 @@ enum TokenType {
 };
 
 // Used as version string for some PEAR packages
-static const char* package_version = "@package_version@";
+static const char* const package_version = "@package_version@";
 
 void *tree_sitter_phpdoc_external_scanner_create() { return NULL; }
 void tree_sitter_phpdoc_external_scanner_destroy(void *p) {}


### PR DESCRIPTION
Main motivation is so the wasm bindings can build without fail, getenv doesn't allow for that, and I think a check for TREE_SITTER_DEBUG shouldn't be used here but only in core