### PR TITLE
Fix rust bindings

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -15,12 +15,9 @@ fn main() {
 
     // If your language uses an external scanner written in C,
     // then include this block of code:
-
-    /*
     let scanner_path = src_dir.join("scanner.c");
     c_config.file(&scanner_path);
     println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    */
 
     c_config.compile("parser");
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());


### PR DESCRIPTION
I was getting ld errors when trying to use this in a rust project. Including the "scanner.c" files in build.rs fixes the issue for me locally. Should address  #34.