### PR TITLE
chore: update to tree-sitter-php v0.24

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -7,6 +7,9 @@ const PHP = require('tree-sitter-php/php/grammar').grammar;
 // TODO array return types https://docs.phpdoc.org/3.0/guide/references/phpdoc/types.html#arrays
 //   @verbatimElement [required element] [<optional element>]
 
+// console.error(JSON.stringify(PHP.reserved.classes[0]));
+// console.error(PHP.reserved.classes[0].value);
+
 module.exports = grammar({
   name: 'phpdoc',
 
@@ -32,6 +35,13 @@ module.exports = grammar({
     ],
     [$.union_type, $.disjunctive_normal_form_type],
   ],
+
+  // copied to mimic the PHP grammar
+  reserved: {
+    global: (_) => PHP.reserved.global.map((k) => new RegExp(k.value, 'i')),
+    classes: (_) => PHP.reserved.classes.map((k) => new RegExp(k.value, 'i')),
+    nothing: (_) => [],
+  },
 
   // Note:
   // 1. External scanners receive text with `extras` not removed yet. So
@@ -481,7 +491,7 @@ module.exports = grammar({
           $.tag_name,
         ),
         // @psalm-trace [name]
-        seq(alias(choice('@psalm-trace'), $.tag_name), $.variable_name),
+        seq(alias('@psalm-trace', $.tag_name), $.variable_name),
         seq(
           alias(choice('@param-out', '@psalm-param-out'), $.tag_name),
           $._type,
@@ -498,10 +508,8 @@ module.exports = grammar({
             $.tag_name,
           ),
           $._type,
-          choice(
-            $.variable_name,
-            // TODO allow PHP expression
-          ),
+          $.variable_name,
+          // TODO allow PHP expression
         ),
         //TODO implement @psalm-taint-* see https://psalm.dev/docs/security_analysis/annotations/
         seq(

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,11 +16,11 @@
       "devDependencies": {
         "prebuildify": "^6.0.0",
         "prettier": "^3.3.3",
-        "tree-sitter-cli": "^0.22.6",
-        "tree-sitter-php": "^0.23.12"
+        "tree-sitter-cli": "^0.25.10",
+        "tree-sitter-php": "^0.24.2"
       },
       "peerDependencies": {
-        "tree-sitter": "^0.21.0"
+        "tree-sitter": "^0.22.0"
       },
       "peerDependenciesMeta": {
         "tree_sitter": {
@@ -347,30 +347,35 @@
       }
     },
     "node_modules/tree-sitter": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
-      "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
+      "version": "0.22.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.4.tgz",
+      "integrity": "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==",
       "hasInstallScript": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "node-addon-api": "^8.0.0",
-        "node-gyp-build": "^4.8.0"
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
       }
     },
     "node_modules/tree-sitter-cli": {
-      "version": "0.22.6",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.22.6.tgz",
-      "integrity": "sha512-s7mYOJXi8sIFkt/nLJSqlYZP96VmKTc3BAwIX0rrrlRxWjWuCwixFqwzxWZBQz4R8Hx01iP7z3cT3ih58BUmZQ==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.25.10.tgz",
+      "integrity": "sha512-KoebQguKMCIghisEOdA372TIbrUl0kdnfZ9YQIBRAeOvNSKe85XbU4LuFW7hduRUwJj0rAG7pX5wo9sZhbBF1g==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "bin": {
         "tree-sitter": "cli.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/tree-sitter-php": {
-      "version": "0.23.12",
-      "resolved": "https://registry.npmjs.org/tree-sitter-php/-/tree-sitter-php-0.23.12.tgz",
-      "integrity": "sha512-VwkBVOahhC2NYXK/Fuqq30NxuL/6c2hmbxEF4jrB7AyR5rLc7nT27mzF3qoi+pqx9Gy2AbXnGezF7h4MeM6YRA==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/tree-sitter-php/-/tree-sitter-php-0.24.2.tgz",
+      "integrity": "sha512-zwgAePc/HozNaWOOfwRAA+3p8yhuehRw8Fb7vn5qd2XjiIc93uJPryDTMYTSjBRjVIUg/KY6pM3rRzs8dSwKfw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -379,7 +384,7 @@
         "node-gyp-build": "^4.8.2"
       },
       "peerDependencies": {
-        "tree-sitter": "^0.21.1"
+        "tree-sitter": "^0.22.4"
       },
       "peerDependenciesMeta": {
         "tree-sitter": {
@@ -398,9 +403,10 @@
       }
     },
     "node_modules/tree-sitter/node_modules/node-addon-api": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.0.0.tgz",
-      "integrity": "sha512-ipO7rsHEBqa9STO5C5T10fj732ml+5kLN1cAG8/jdHd56ldQeGj3Q7+scUS+VHK/qy1zLEwC4wMK5+yM0btPvw==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": "^18 || ^20 || >= 21"

--- a/package.json
+++ b/package.json
@@ -40,15 +40,15 @@
   "devDependencies": {
     "prebuildify": "^6.0.0",
     "prettier": "^3.3.3",
-    "tree-sitter-cli": "^0.22.6",
-    "tree-sitter-php": "^0.23.12"
+    "tree-sitter-cli": "^0.25.10",
+    "tree-sitter-php": "^0.24.2"
   },
   "dependencies": {
     "node-addon-api": "^7.1.0",
     "node-gyp-build": "^4.8.0"
   },
   "peerDependencies": {
-    "tree-sitter": "^0.21.0"
+    "tree-sitter": "^0.22.0"
   },
   "peerDependenciesMeta": {
     "tree_sitter": {

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -1,0 +1,32 @@
+{
+  "grammars": [
+    {
+      "name": "phpdoc",
+      "camelcase": "PHPDoc",
+      "scope": "source.php",
+      "path": "php",
+      "file-types": ["php"]
+    }
+  ],
+  "metadata": {
+    "version": "0.1.8",
+    "license": "MIT",
+    "description": "PHPDoc grammar for tree-sitter",
+    "authors": [
+      {
+        "name": "Clayton Carter"
+      }
+    ],
+    "links": {
+      "repository": "https://github.com/claytonrcarter/tree-sitter-phpdoc"
+    }
+  },
+  "bindings": {
+    "c": true,
+    "go": false,
+    "node": true,
+    "python": true,
+    "rust": true,
+    "swift": true
+  }
+}


### PR DESCRIPTION
I'm parking this here for now, perhaps others can take a peek and offer suggestions.

Updating to tree-sitter-php v0.24 also needs an update to tree-sitter v0.25, because the PHP grammar is making use of the `reserved()` API that was introduced in that version. I've been able to pull in the `reserved` settings from the PHP grammar and (I think) wire them up, but I'm stuck with a error:

```
❯ ./node_modules/.bin/tree-sitter generate
Error when generating parser

Caused by:
    Reserved word 'abstract' must be a token
```

This error seems to be coming from https://github.com/tree-sitter/tree-sitter/blob/eacb95c85da15005f091729f3225609d0db67963/crates/generate/src/prepare_grammar/extract_tokens.rs#L225, but I suspect that we are just missing some other grammar config, because even just copying the PHP reserved words into this grammar as static strings (vs trying to import/rebuild, as in this PR) results in this error. And changing the value of the first entry in the `classes` reserved set will just give the same error, but w/ the updated value:

```
reserved: {
    classes: (_) => ['foobar'],
  },

...

Error when generating parser

Caused by:
    Reserved word 'foobar' must be a token
```

So I suspect that I'm just missing something about this new API and how it works, or some other change that happened when the PHP grammar adopted the new API in https://github.com/tree-sitter/tree-sitter-php/commit/33d700240cdde660412b19f406e922834d1ac4da

Suggestions and input are welcome!